### PR TITLE
Fix unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ file(GLOB_RECURSE game_files
     src/Games/*.hpp
     )
 
+# tests
+file(GLOB_RECURSE test_files
+    test/src/*.cpp
+    test/src/*.hpp
+    )
+
 # To add another game-mode create a directory such as "src/Games/[GameModeName]" constaining your
 # GameMode class. Any resources can be provided in "resources/[GameModeName]". Include the file in
 # main.cpp and add it to the GameModeController with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(GoogleTest)
 FetchContent_Declare(
     SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git
-    GIT_TAG 2.6.x)
+    GIT_TAG 2.6.1)
 FetchContent_MakeAvailable(SFML)
 
 # gtest - requires cmake 3.13 or later
@@ -94,13 +94,13 @@ if (BUILD_TESTS)
     target_include_directories(testAll
         PRIVATE
         ${CMAKE_SOURCE_DIR}/src/
-        ${CMAKE_SOURCE_DIR}/test/src/
+        ${CMAKE_SOURCE_DIR}/test/
     )
 
     target_link_libraries(testAll GTest::gtest_main)
     target_compile_features(testAll PRIVATE cxx_std_20)
-    gtest_discover_tests(testAll DISCOVERY_TIMEOUT 600)
-    # gtest_discover_tests(testAll)
+    gtest_discover_tests(testAll
+        DISCOVERY_TIMEOUT 600)
 endif()
 
 # linker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(GoogleTest)
 FetchContent_Declare(
     SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git
-    GIT_TAG 2.6.1)
+    GIT_TAG 2.6.x)
 FetchContent_MakeAvailable(SFML)
 
 # gtest - requires cmake 3.13 or later
@@ -105,8 +105,7 @@ if (BUILD_TESTS)
 
     target_link_libraries(testAll GTest::gtest_main)
     target_compile_features(testAll PRIVATE cxx_std_20)
-    gtest_discover_tests(testAll
-        DISCOVERY_TIMEOUT 600)
+    gtest_discover_tests(testAll DISCOVERY_TIMEOUT 600)
 endif()
 
 # linker

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,8 @@ mkdir build
 # set clang version
 export CC="/usr/bin/clang-17"
 export CXX="/usr/bin/clang++-17"
+export CMAKE_GENERATOR=Ninja
 
 # cmake
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build
+cmake --build build -j10

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,6 @@ mkdir build
 # set clang version
 export CC="/usr/bin/clang-17"
 export CXX="/usr/bin/clang++-17"
-export CMAKE_GENERATOR=Ninja
 
 # cmake
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug

--- a/setup.sh
+++ b/setup.sh
@@ -11,4 +11,4 @@ export CMAKE_GENERATOR=Ninja
 
 # cmake
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build -j10
+cmake --build build -j24


### PR DESCRIPTION
### Bug
PR #21 introduced a bug causing tests discovery to fail

### Cause
Test file includes were erroneously removed from the makefile

### Fix
Added test file includes back to the makefile

### Note
Added -j24 to setup.sh to speed up compilation